### PR TITLE
Bump compat for JuMP packages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "NonconvexJuniper"
 uuid = "611adb69-ebe7-45d0-83f5-90aabba2c123"
 authors = ["Mohamed Tarek <mohamed82008@gmail.com> and contributors"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 Ipopt = "b6b21f68-93f8-5de0-b562-5493be1d77c9"
@@ -17,10 +17,10 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [compat]
-Ipopt = "0.9"
-JuMP = "0.22"
-Juniper = "0.8"
-MathOptInterface = "0.10"
+Ipopt = "0.9, 1"
+JuMP = "0.22, 0.23"
+Juniper = "0.8, 0.9"
+MathOptInterface = "0.10, 1"
 NonconvexCore = "1"
 NonconvexIpopt = "0.1.2"
 Parameters = "0.12"


### PR DESCRIPTION
This will need https://github.com/JuliaNonconvex/NonconvexIpopt.jl/pull/7 before it will pull in the latest versions